### PR TITLE
[DSY-1519] chore: remove references from natds-js

### DIFF
--- a/packages/natds-icons/package.json
+++ b/packages/natds-icons/package.json
@@ -3,19 +3,22 @@
   "displayName": "NatDS Icons",
   "version": "0.22.0",
   "private": false,
-  "description": "A collection of icons for Natura Design System",
+  "description": "A collection of icons for Natura & Co. Design System",
   "keywords": [
     "design-system",
     "icons",
     "natds",
     "natura"
   ],
-  "homepage": "https://github.com/natura-cosmeticos/natds-js/tree/master/packages/icons/README.md",
+  "homepage": "https://github.com/natura-cosmeticos/natds-commons/tree/master/packages/natds-icons#readme",
   "bugs": {
-    "url": "https://github.com/natura-cosmeticos/natds-js/issues"
+    "url": "https://github.com/natura-cosmeticos/natds-commons/issues"
   },
   "license": "ISC",
-  "author": "Natura Cosméticos <designsystem@natura.net>",
+  "author": {
+    "email": "designsystem@natura.net",
+    "name": "Natura & Co."
+  },
   "contributors": [
     "Ariel Flor <aflor@thoughtworks.com>",
     "Daniel Castro <daniel.castro@vizir.com.br>",
@@ -38,7 +41,7 @@
   "repository": {
     "directory": "packages/icons",
     "type": "git",
-    "url": "https://github.com/natura-cosmeticos/natds.git"
+    "url": "https://github.com/natura-cosmeticos/natds-commons.git"
   },
   "directories": {
     "lib": "./dist"


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes for `natds-icons` package manifest file:

- Replace "Natura" by "Natura & Co.";
- Replace homepage, bugs and repository references from `natds-js` to `natds-commons`;

No dependencies were added, updated or removed.

### Related issue

[DSY-1519](https://natura.atlassian.net/browse/DSY-1519) (internal only)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
