### PR TITLE
chore(natds-icons): add `/dist` files to safelist

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -15,7 +15,10 @@ excluded_files:
   - "yarn.lock"
   - "Gemfile.lock"
   - ".typo-ci.yml"
+  - "packages/natds-icons/dist/**/*"
 excluded_words:
+  - cosmeticos
+  - cosméticos
   - cti
   - natds
   - natds-themes


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Prevent files inside `packages/natds-icons/dist/**/*` from being checked by Typo CI;
- Add `cosmeticos` and `cósmeticos` portuguese words to Typo CI safelist.

No dependencies were added, updated or removed.

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
