### PR TITLE
[DSY-1519] fix: add missing typings file for fonts

### DIFF
--- a/packages/natds-icons/typings/fonts.d.ts
+++ b/packages/natds-icons/typings/fonts.d.ts
@@ -1,0 +1,5 @@
+declare module "*.eot";
+declare module "*.svg";
+declare module "*.ttf";
+declare module "*.woff";
+declare module "*.woff2";


### PR DESCRIPTION
## Summary

### Proposed changes

This PR proposes the following changes:

- [x] Add typings folder with font module definitions to prevent TypeScript errors when using `natds-icons` from `natds-web`.
- [ ] Don't ignore `typings/` folder at `.gitignore`;
- [ ] Remove `@todo` comment from `svgToFont.js`, if applicable;
- [ ] Remove redundant `declare module "*.json";` from `declaration.d.ts`;
- [ ] Add `"./typings/**/*.d.ts"` to `tsconfig.json`;

No dependencies were added, updated or removed.

### Related issue

[DSY-1519](https://natura.atlassian.net/browse/DSY-1519) (internal only)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
