### PR TITLE
fix(icons): prevent import font imports from index [DSY-1519]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "lerna run lint:fix",
     "copy:html:assets": "mkdir -p build && cp -r packages/natds-themes/build/html/* build && cp -r packages/natds-token-search/dist/* build",
     "html:build": "yarn build && yarn copy:html:assets",
-    "release:alpha": "yarn release --conventional-prerelease",
+    "release:alpha": "yarn release --conventional-prerelease --no-commit-hooks",
     "release:alpha-ci": "yarn release:alpha --yes",
     "reinstall": "yarn clean && rm -rf ./node_modules && rm -rf yarn.lock && yarn install && yarn bootstrap",
     "release": "lerna version --conventional-commits",

--- a/packages/natds-icons/dist/index.d.ts
+++ b/packages/natds-icons/dist/index.d.ts
@@ -1,8 +1,4 @@
-import * as iconStyles from './natds-icons.css';
-import iconNames from './natds-icons.json';
-import * as NatdsIconsEot from './fonts/natds-icons.eot';
-import * as NatdsIconsSvg from './fonts/natds-icons.svg';
-import * as NatdsIconsTtf from './fonts/natds-icons.ttf';
-import * as NatdsIconsWoff from './fonts/natds-icons.woff';
-import * as NatdsIconsWoff2 from './fonts/natds-icons.woff2';
-export { iconNames, iconStyles, NatdsIconsEot, NatdsIconsSvg, NatdsIconsTtf, NatdsIconsWoff, NatdsIconsWoff2, };
+import icons from './natds-icons.json';
+declare const iconNames: string[];
+export declare type IconName = keyof typeof icons;
+export { icons, iconNames, };

--- a/packages/natds-icons/dist/index.js
+++ b/packages/natds-icons/dist/index.js
@@ -1,40 +1,4 @@
-"use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.NatdsIconsWoff2 = exports.NatdsIconsWoff = exports.NatdsIconsTtf = exports.NatdsIconsSvg = exports.NatdsIconsEot = exports.iconStyles = exports.iconNames = void 0;
-var iconStyles = __importStar(require("./natds-icons.css"));
-exports.iconStyles = iconStyles;
-var natds_icons_json_1 = __importDefault(require("./natds-icons.json"));
-exports.iconNames = natds_icons_json_1.default;
-var NatdsIconsEot = __importStar(require("./fonts/natds-icons.eot"));
-exports.NatdsIconsEot = NatdsIconsEot;
-var NatdsIconsSvg = __importStar(require("./fonts/natds-icons.svg"));
-exports.NatdsIconsSvg = NatdsIconsSvg;
-var NatdsIconsTtf = __importStar(require("./fonts/natds-icons.ttf"));
-exports.NatdsIconsTtf = NatdsIconsTtf;
-var NatdsIconsWoff = __importStar(require("./fonts/natds-icons.woff"));
-exports.NatdsIconsWoff = NatdsIconsWoff;
-var NatdsIconsWoff2 = __importStar(require("./fonts/natds-icons.woff2"));
-exports.NatdsIconsWoff2 = NatdsIconsWoff2;
+import icons from './natds-icons.json';
+const iconNames = Object.keys(icons);
+export { icons, iconNames, };
 //# sourceMappingURL=index.js.map

--- a/packages/natds-icons/dist/index.js.map
+++ b/packages/natds-icons/dist/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAAA,4DAAgD;AAU9C,gCAAU;AATZ,wEAA2C;AAQzC,oBARK,0BAAS,CAQL;AAPX,qEAAyD;AASvD,sCAAa;AARf,qEAAyD;AASvD,sCAAa;AARf,qEAAyD;AASvD,sCAAa;AARf,uEAA2D;AASzD,wCAAc;AARhB,yEAA6D;AAS3D,0CAAe"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,MAAM,oBAAoB,CAAC;AAEvC,MAAM,SAAS,GAAG,MAAM,CAAC,IAAI,CAAC,KAAK,CAAC,CAAA;AAIpC,OAAO,EACL,KAAK,EACL,SAAS,GACV,CAAC"}

--- a/packages/natds-icons/dist/index.ts
+++ b/packages/natds-icons/dist/index.ts
@@ -1,17 +1,10 @@
-import * as iconStyles from './natds-icons.css';
-import iconNames from './natds-icons.json';
-import * as NatdsIconsEot from './fonts/natds-icons.eot';
-import * as NatdsIconsSvg from './fonts/natds-icons.svg';
-import * as NatdsIconsTtf from './fonts/natds-icons.ttf';
-import * as NatdsIconsWoff from './fonts/natds-icons.woff';
-import * as NatdsIconsWoff2 from './fonts/natds-icons.woff2';
+import icons from './natds-icons.json';
+
+const iconNames = Object.keys(icons)
+
+export type IconName = keyof typeof icons;
 
 export {
+  icons,
   iconNames,
-  iconStyles,
-  NatdsIconsEot,
-  NatdsIconsSvg,
-  NatdsIconsTtf,
-  NatdsIconsWoff,
-  NatdsIconsWoff2,
 };

--- a/packages/natds-icons/dist/natds-icons.json.d.ts
+++ b/packages/natds-icons/dist/natds-icons.json.d.ts
@@ -231,4 +231,4 @@ interface RootObject {
 }
 declare const styles : RootObject;
 
-export = styles;
+export default styles;

--- a/packages/natds-icons/package.json
+++ b/packages/natds-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@naturacosmeticos/natds-icons",
   "displayName": "NatDS Icons",
-  "version": "0.25.0",
+  "version": "1.0.0-alpha.0",
   "private": false,
   "description": "A collection of icons for Natura & Co. Design System",
   "keywords": [
@@ -81,8 +81,13 @@
     "svgo": "1.3.2",
     "tslib": "2.0.3",
     "typed-css-modules": "0.6.4",
-    "typescript": "4.1.2",
-    "webfont": "9.0.0"
+    "typescript": "4.0.3",
+    "webfont": "9.0.0",
+    "puppeteer": "^5.3.1",
+    "ramda": "^0.27.1",
+    "string.fromcodepoint": "^1.0.0",
+    "string.prototype.codepointat": "^1.0.0",
+    "svg2vectordrawable": "^2.6.26"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -90,11 +95,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "puppeteer": "^5.3.1",
-    "ramda": "^0.27.1",
-    "string.fromcodepoint": "^1.0.0",
-    "string.prototype.codepointat": "^1.0.0",
-    "svg2vectordrawable": "^2.6.26"
-  }
+  "dependencies": {}
 }

--- a/packages/natds-icons/package.json
+++ b/packages/natds-icons/package.json
@@ -32,10 +32,11 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "browser": "dist/umd/index.js",
   "jsdelivr": "dist/umd/index.js",
-  "source": "src/index.ts",
+  "source": "dist/index.ts",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "unpkg": "dist/umd/index.js",

--- a/packages/natds-icons/rollup.config.js
+++ b/packages/natds-icons/rollup.config.js
@@ -1,9 +1,8 @@
 import json from '@rollup/plugin-json';
-import url from '@rollup/plugin-url';
 
 export default {
   external: [],
-  input: './dist/index.ts',
+  input: './dist/index.js',
   output: [
     {
       dir: './dist/cjs',
@@ -30,15 +29,5 @@ export default {
   ],
   plugins: [
     json(),
-    url({
-      include: [
-        '**/*.css',
-        '**/*.eot',
-        '**/*.svg',
-        '**/*.ttf',
-        '**/*.woff',
-        '**/*.woff2',
-      ],
-    }),
   ],
 };

--- a/packages/natds-icons/src/actions/buildJsonDts.js
+++ b/packages/natds-icons/src/actions/buildJsonDts.js
@@ -11,7 +11,7 @@ export const buildJsonDts = (data) => {
 
   const jsonDts = JsonToTS(JSON.parse(content))
     .reduce((types, typeInterface) => types.concat(typeInterface), '')
-    .concat('\ndeclare const styles : RootObject;\n\nexport = styles;\n');
+    .concat('\ndeclare const styles : RootObject;\n\nexport default styles;\n');
 
   const jsonDtsOutput = {
     content: jsonDts,

--- a/packages/natds-icons/src/actions/buildJsonDts.test.js
+++ b/packages/natds-icons/src/actions/buildJsonDts.test.js
@@ -30,7 +30,7 @@ interface RootObject {
 }
 declare const styles : RootObject;
 
-export = styles;
+export default styles;
 `;
 
 describe('buildJsonDts', () => {

--- a/packages/natds-icons/src/static/index.ts
+++ b/packages/natds-icons/src/static/index.ts
@@ -1,17 +1,10 @@
-import * as iconStyles from './natds-icons.css';
-import iconNames from './natds-icons.json';
-import * as NatdsIconsEot from './fonts/natds-icons.eot';
-import * as NatdsIconsSvg from './fonts/natds-icons.svg';
-import * as NatdsIconsTtf from './fonts/natds-icons.ttf';
-import * as NatdsIconsWoff from './fonts/natds-icons.woff';
-import * as NatdsIconsWoff2 from './fonts/natds-icons.woff2';
+import icons from './natds-icons.json';
+
+const iconNames = Object.keys(icons)
+
+export type IconName = keyof typeof icons;
 
 export {
+  icons,
   iconNames,
-  iconStyles,
-  NatdsIconsEot,
-  NatdsIconsSvg,
-  NatdsIconsTtf,
-  NatdsIconsWoff,
-  NatdsIconsWoff2,
 };

--- a/packages/natds-icons/tsconfig.json
+++ b/packages/natds-icons/tsconfig.json
@@ -12,7 +12,7 @@
       "es2017",
       "dom"
     ],
-    "module": "commonjs",
+    "module": "ESNext",
     "moduleResolution": "node",
     "newLine": "lf",
     "noImplicitAny": false,
@@ -25,7 +25,7 @@
     "sourceMap": true,
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es5",
+    "target": "ESNext",
     "types": ["jest"]
   },
   "include": [


### PR DESCRIPTION
DSY-1519

# Description

This PR removes font file imports from the index and adds some utility data like `IconName` type definition and the `iconNames` array.

Also prevents the following issue:

```
TS1259: Module '"/node_modules/@naturacosmeticos/natds-icons/dist/natds-icons.json"' can only be default-imported using the 'esModuleInterop' flag
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
