### PR TITLE
fix(natds-icons): change css font-display from auto to swap

### DIFF
--- a/packages/natds-icons/dist/natds-icons.css
+++ b/packages/natds-icons/dist/natds-icons.css
@@ -2,7 +2,7 @@
   font-family: "natds-icons";
   font-style: normal;
   font-weight: 400;
-  font-display: auto;
+  font-display: swap;
   src: url("./fonts/natds-icons.eot");
   src: url("./fonts/natds-icons.eot?#iefix") format("embedded-opentype"), url("./fonts/natds-icons.woff2") format("woff2"), url("./fonts/natds-icons.woff") format("woff"), url("./fonts/natds-icons.ttf") format("truetype"), url("./fonts/natds-icons.svg#natds-icons") format("svg");
 }

--- a/packages/natds-icons/src/actions/buildCss.js
+++ b/packages/natds-icons/src/actions/buildCss.js
@@ -5,8 +5,10 @@ export const buildCss = (data) => {
 
   const { globalConfig: { fontName, outputPath }, template } = data;
 
+  const content = template.replace('font-display: auto;', 'font-display: swap;');
+
   const css = {
-    content: template,
+    content,
     outputPath: `${outputPath}/${fontName}.css`,
   };
 

--- a/packages/natds-icons/src/actions/buildCss.test.js
+++ b/packages/natds-icons/src/actions/buildCss.test.js
@@ -17,7 +17,7 @@ describe('buildCss', () => {
     }
   });
 
-  it('should crate the css output', () => {
+  it('should create the css output', () => {
     const result = buildCss(data);
 
     expect(result).toEqual({
@@ -29,5 +29,26 @@ describe('buildCss', () => {
         },
       },
     });
+  });
+
+  it('should replace the font display to swap', () => {
+    const templateWithDisplay = {
+      ...data,
+      template: '@font-face {font-display: auto;}',
+    };
+
+    const expectedOutput = {
+      ...templateWithDisplay,
+      outputs: {
+        css: {
+          content: '@font-face {font-display: swap;}',
+          outputPath: 'folder/name/font-name.css',
+        },
+      },
+    };
+
+    const result = buildCss(templateWithDisplay);
+
+    expect(result).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
affects: @naturacosmeticos/natds-icons

# Description

This PR changes the css font-display property from auto to swap

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
