### PR TITLE
fix(natds-themes):  fixed Avon-V2  asset b height 58 to 256

### DIFF
--- a/packages/natds-themes/properties/brands/avon_v2/asset-dark.json
+++ b/packages/natds-themes/properties/brands/avon_v2/asset-dark.json
@@ -21,7 +21,7 @@
             "value": 256
           },
           "height": {
-            "value": 58
+            "value": 256
           }
         }
       },
@@ -45,7 +45,7 @@
             "value": 256
           },
           "height": {
-            "value": 58
+            "value": 256
           }
         }
       }

--- a/packages/natds-themes/properties/brands/avon_v2/asset-light.json
+++ b/packages/natds-themes/properties/brands/avon_v2/asset-light.json
@@ -21,7 +21,7 @@
             "value": 256
           },
           "height": {
-            "value": 58
+            "value": 256
           }
         }
       },
@@ -45,7 +45,7 @@
             "value": 256
           },
           "height": {
-            "value": 58
+            "value": 256
           }
         }
       }


### PR DESCRIPTION
affects: natds-themes
DSY-5461

# Description

fixed Avon-V2  asset b height 58 to 256

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
